### PR TITLE
Ability to control visible items in dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Vue.use(Autocomplete)
 
 ```html
 <template>
-  <v-autocomplete :items="items" v-model="item" :get-label="getLabel" :component-item='template' @update-items="updateItems">
+  <v-autocomplete :items="items" v-model="item" :get-label="getLabel" :visible-items=10 :component-item='template' @update-items="updateItems">
   </v-autocomplete>
 </template>
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Properties
 | ------------------------ | ----------------------------------- | -------- | ------------------------------ | ------------------------------------------------------------------------------------------------------ |
 | **items**                | Array                               | Yes      |                                | List items                                                                                             |
 | **component-item**       | Vue Component or Function or String | No       | Item                           | Item list template                                                                                     |
+| **visible-items**        | Number                              | No       |                                | Number of items to show in dropdown menu                                                               |
 | **min-len**              | Number                              | No       | 3                              | Min length to trigger the *updateItems* event                                                          |
 | **wait**                 | String                              | No       | 500                            | Miliseconds dela to trigger the *updateItems* event                                                    |
 | **get-label**            | Function                            | No       | function(item) { return item } | Anonymous function to extract label of the item                                                        |

--- a/demo/App.vue
+++ b/demo/App.vue
@@ -2,7 +2,7 @@
 div(style="text-align: center;")
   h2 Type some animal name to search
 
-  v-autocomplete(:items="items" v-model='item', :get-label='getLabel', :min-len='0' @update-items='update', :component-item='tpl', @item-selected="itemSelected", @item-clicked="itemClicked", :input-attrs="{name: 'input-test', id: 'v-my-autocomplete'}")
+  v-autocomplete(:items="items" v-model='item', :visible-items=10, :get-label='getLabel', :min-len='0' @update-items='update', :component-item='tpl', @item-selected="itemSelected", @item-clicked="itemClicked", :input-attrs="{name: 'input-test', id: 'v-my-autocomplete'}")
   p Selected item:
   pre {{ item }}
 

--- a/src/Autocomplete.vue
+++ b/src/Autocomplete.vue
@@ -39,7 +39,8 @@ export default {
     inputClass: {type: String, default: 'v-autocomplete-input'},
     disabled: {type: Boolean, default: false},
     inputAttrs: {type: Object, default: () => {return {}}},
-    keepOpen: {type: Boolean, default: false}
+    keepOpen: {type: Boolean, default: false},
+    visibleItems: null
   },
   data () {
     return {
@@ -96,6 +97,10 @@ export default {
     },
 
     setItems (items) {
+      if(this.visibleItems){
+        this.internalItems = items.slice(0, this.visibleItems) || [];
+        return;
+      }
       this.internalItems = items || []
     },
 

--- a/src/Autocomplete.vue
+++ b/src/Autocomplete.vue
@@ -97,11 +97,10 @@ export default {
     },
 
     setItems (items) {
-      if(this.visibleItems){
-        this.internalItems = items.slice(0, this.visibleItems) || [];
-        return;
-      }
-      this.internalItems = items || []
+      var items_length = items.length;
+      if(!isNaN(this.visibleItems))
+        items_length = this.visibleItems;
+      this.internalItems = items.slice(0, items_length) || [];
     },
 
     isSelecteValue (value) {
@@ -140,6 +139,10 @@ export default {
     utils.minLen = this.minLen
     utils.wait = this.wait
     this.onSelectItem(this.value)
+
+    if(isNaN(this.visibleItems)){
+      console.warn("Please enter valid number in visible-items.")
+    }
   },
   watch: {
     items (newValue) {


### PR DESCRIPTION
## Feature
Functionality to control visible items in dropdown. 

## Description 
Right now, there is no way to control how many items we can show in drop-down of suggestion. I have added this configuration `visible-items`. Providing a value to it will slice the array and provide parent component with the top selected items. 

## Usage
HTML
```
<v-autocomplete :visible-items=10 :items="items" v-model="item" :get-label="getLabel"  :component-item='template' @update-items="updateItems">
  </v-autocomplete>
```
If this value is not provided, UI will show all items in a dropdown. 

Cheers 🍺
Rahul.