### PR TITLE
Added a ref directive to the input field.

### DIFF
--- a/src/Autocomplete.vue
+++ b/src/Autocomplete.vue
@@ -1,7 +1,7 @@
 <template lang="html">
   <div class="v-autocomplete">
     <div class="v-autocomplete-input-group" :class="{'v-autocomplete-selected': value}">
-      <input type="search" v-model="searchText" v-bind="inputAttrs" 
+      <input type="search" v-model="searchText" v-bind="inputAttrs" ref="input"
             :class="inputAttrs.class || inputClass"
             :placeholder="inputAttrs.placeholder || placeholder"
             :disabled="inputAttrs.disabled || disabled"


### PR DESCRIPTION
A ref directive was added to the input field to allow it to be referenced from outside the component, for example to set input focus. If a ref directive is added to the v-autocomplete component you can reference the input field inside the component like this:
```
this.$refs['autocomplete'].$refs['input'].focus()
```
where 'autocomplete' is the component ref and 'input' is the input field ref. A name of 'input' was used since it's obvious what it refers to and there are not other refs in the component thta it might clash with.