### PR TITLE
Adding autocomplete property on input field

### DIFF
--- a/src/Autocomplete.vue
+++ b/src/Autocomplete.vue
@@ -1,7 +1,7 @@
 <template lang="html">
   <div class="v-autocomplete">
     <div class="v-autocomplete-input-group" :class="{'v-autocomplete-selected': value}">
-      <input type="search" v-model="searchText" v-bind="inputAttrs" 
+      <input type="search" autocomplete="nope" v-model="searchText" v-bind="inputAttrs" 
             :class="inputAttrs.class || inputClass"
             :placeholder="inputAttrs.placeholder || placeholder"
             :disabled="inputAttrs.disabled || disabled"


### PR DESCRIPTION
This change is very simple but will prevent the autocomplete browser function overwrite the options list of component, like below:
![image](https://user-images.githubusercontent.com/1553078/66722219-4bfff180-ede1-11e9-9e4e-9fd80ae7f0b6.png)
If I type ESC, this option exists and I can see the list:
![image](https://user-images.githubusercontent.com/1553078/66722229-70f46480-ede1-11e9-8342-8b6fcfbe573f.png)

With this change, the browser never will exhibit your options over the component.